### PR TITLE
feat: Adding support for serverlessv2 scaling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,15 @@ No modules.
 | <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | Cluster identifier | `string` | `"aurora"` | no |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance type to use at replica instance | `string` | `"db.r5.large"` | no |
+| <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Requires serverless\_scaling to be set to true. The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. | `string` | `"2.0"` | no |
+| <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Requires serverless\_scaling to be set to true. The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster | `string` | `"1.0"` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | Enhanced Monitoring interval in seconds | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Prefix for resource names | `string` | `"aurora"` | no |
 | <a name="input_port"></a> [port](#input\_port) | The port on which to accept connections | `string` | `""` | no |
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | When to perform DB backups | `string` | `"02:00-03:00"` | no |
 | <a name="input_primary_instance_count"></a> [primary\_instance\_count](#input\_primary\_instance\_count) | instance count for primary Aurora cluster | `number` | `2` | no |
 | <a name="input_secondary_instance_count"></a> [secondary\_instance\_count](#input\_secondary\_instance\_count) | instance count for secondary Aurora cluster | `number` | `1` | no |
+| <a name="input_serverless_scaling"></a> [serverless\_scaling](#input\_serverless\_scaling) | Boolean to enable or disable Serverless v2 autoscaling for the cluster | `bool` | `false` | no |
 | <a name="input_setup_as_secondary"></a> [setup\_as\_secondary](#input\_setup\_as\_secondary) | Setup aws\_rds\_cluster.primary Terraform resource as Secondary Aurora cluster after an unplanned Aurora Global DB failover | `bool` | `false` | no |
 | <a name="input_setup_globaldb"></a> [setup\_globaldb](#input\_setup\_globaldb) | Setup Aurora Global Database with 1 Primary and 1 X-region Secondary cluster | `bool` | `false` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | skip creating a final snapshot before deleting the DB | `bool` | `true` | no |

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -44,6 +44,24 @@ variable "password" {
   description = "If no password is provided, a random password will be generated"
 }
 
+variable "serverless_scaling" {
+  description = "Boolean to enable or disable Serverless v2 autoscaling for the cluster"
+  type    = bool
+  default = false
+}
+
+variable "min_capacity" {
+  description = "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster"
+  type        = string
+  default     = "1.0"
+}
+
+variable "max_capacity" {
+  description = "The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster."
+  type        = string
+  default     = "2.0"
+}
+
 /*
 variable "tags" {
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,24 @@ variable "database_name" {
   default     = "mydb"
 }
 
+variable "serverless_scaling" {
+  description = "Boolean to enable or disable Serverless v2 autoscaling for the cluster"
+  type        = bool
+  default     = false
+}
+
+variable "min_capacity" {
+  description = "Requires serverless_scaling to be set to true. The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster"
+  type        = string
+  default     = "1.0"
+}
+
+variable "max_capacity" {
+  description = "Requires serverless_scaling to be set to true. The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster."
+  type        = string
+  default     = "2.0"
+}
+
 variable "username" {
   description = "Master DB username"
   type        = string


### PR DESCRIPTION
# Summary

Adding support for Serverlessv2 scaling configuration. This change enables the use of the `db.serverless` instance class as well as configuring the minimum and maximum capacity for scaling.

The change will be opt-in through the use of a condition and a boolean.

Solves #14

# Testing

## tf plan output when `serverless_scaling` set to true and instance class set to `db.serverless`

```
# module.rds-aurora.aws_rds_cluster.primary will be created
  + resource "aws_rds_cluster" "primary" {
      + allocated_storage                = (known after apply)
      + allow_major_version_upgrade      = true
      + apply_immediately                = true
      + arn                              = (known after apply)
      + availability_zones               = [
          + "ap-southeast-2a",
          + "ap-southeast-2b",
          + "ap-southeast-2c",
        ]
      + backup_retention_period          = 7
      + cluster_identifier               = "aurora-ap-southeast-2"
      + cluster_identifier_prefix        = (known after apply)
      + cluster_members                  = (known after apply)
      + cluster_resource_id              = (known after apply)
      + copy_tags_to_snapshot            = false
      + database_name                    = "amazon"
      + db_cluster_parameter_group_name  = (known after apply)
      + db_instance_parameter_group_name = (known after apply)
      + db_subnet_group_name             = "aurora-sg"
      + db_system_id                     = (known after apply)
      + delete_automated_backups         = true
      + enable_global_write_forwarding   = false
      + enable_http_endpoint             = false
      + endpoint                         = (known after apply)
      + engine                           = "aurora-postgresql"
      + engine_mode                      = "provisioned"
      + engine_version                   = "13.7"
      + engine_version_actual            = (known after apply)
      + hosted_zone_id                   = (known after apply)
      + iam_roles                        = (known after apply)
      + id                               = (known after apply)
      + kms_key_id                       = (known after apply)
      + master_password                  = (sensitive value)
      + master_user_secret               = (known after apply)
      + master_user_secret_kms_key_id    = (known after apply)
      + master_username                  = "admins"
      + network_type                     = (known after apply)
      + port                             = 5432
      + preferred_backup_window          = "02:00-03:00"
      + preferred_maintenance_window     = (known after apply)
      + reader_endpoint                  = (known after apply)
      + skip_final_snapshot              = true
      + storage_encrypted                = false
      + storage_type                     = (known after apply)
      + tags                             = {
          + "Name" = "aurora-db"
        }
      + tags_all                         = {
          + "Name" = "aurora-db"
        }
      + vpc_security_group_ids           = (known after apply)

      + serverlessv2_scaling_configuration {
          + max_capacity = 2
          + min_capacity = 1
        }
    }
```

## tf plan output when `serverless_scaling` set to false

```
# module.rds-aurora.aws_rds_cluster_instance.primary[1] will be created
  + resource "aws_rds_cluster_instance" "primary" {
      + apply_immediately                     = true
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + ca_cert_identifier                    = (known after apply)
      + cluster_identifier                    = (known after apply)
      + copy_tags_to_snapshot                 = false
      + db_parameter_group_name               = (known after apply)
      + db_subnet_group_name                  = "aurora-sg"
      + dbi_resource_id                       = (known after apply)
      + endpoint                              = (known after apply)
      + engine                                = "aurora-postgresql"
      + engine_version                        = "13.7"
      + engine_version_actual                 = (known after apply)
      + id                                    = (known after apply)
      + identifier                            = "aurora-ap-southeast-2-2"
      + identifier_prefix                     = (known after apply)
      + instance_class                        = "db.r5.large"
      + kms_key_id                            = (known after apply)
      + monitoring_interval                   = 1
      + monitoring_role_arn                   = (known after apply)
      + network_type                          = (known after apply)
      + performance_insights_enabled          = true
      + performance_insights_kms_key_id       = (known after apply)
      + performance_insights_retention_period = (known after apply)
      + port                                  = (known after apply)
      + preferred_backup_window               = (known after apply)
      + preferred_maintenance_window          = (known after apply)
      + promotion_tier                        = 0
      + publicly_accessible                   = (known after apply)
      + storage_encrypted                     = (known after apply)
      + tags                                  = {
          + "Name" = "aurora-db"
        }
      + tags_all                              = {
          + "Name" = "aurora-db"
        }
      + writer                                = (known after apply)
    }

```