### PR TITLE
Add VPC security ids assocation for the Aurora cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ No modules.
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | When to perform DB backups | `string` | `"02:00-03:00"` | no |
 | <a name="input_primary_instance_count"></a> [primary\_instance\_count](#input\_primary\_instance\_count) | instance count for primary Aurora cluster | `number` | `2` | no |
 | <a name="input_secondary_instance_count"></a> [secondary\_instance\_count](#input\_secondary\_instance\_count) | instance count for secondary Aurora cluster | `number` | `1` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of VPC security groups to associate with the Cluster | `list(string)` | `[]` | no |
 | <a name="input_setup_as_secondary"></a> [setup\_as\_secondary](#input\_setup\_as\_secondary) | Setup aws\_rds\_cluster.primary Terraform resource as Secondary Aurora cluster after an unplanned Aurora Global DB failover | `bool` | `false` | no |
 | <a name="input_setup_globaldb"></a> [setup\_globaldb](#input\_setup\_globaldb) | Setup Aurora Global Database with 1 Primary and 1 X-region Secondary cluster | `bool` | `false` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | skip creating a final snapshot before deleting the DB | `bool` | `true` | no |
@@ -172,4 +173,5 @@ No modules.
 | <a name="output_aurora_cluster_port"></a> [aurora\_cluster\_port](#output\_aurora\_cluster\_port) | Primary Aurora cluster endpoint port |
 | <a name="output_aurora_cluster_reader_endpoint"></a> [aurora\_cluster\_reader\_endpoint](#output\_aurora\_cluster\_reader\_endpoint) | Primary Aurora cluster reader endpoint |
 | <a name="output_aurora_cluster_resource_id"></a> [aurora\_cluster\_resource\_id](#output\_aurora\_cluster\_resource\_id) | The Cluster Resource ID of the Primary Aurora cluster |
+| <a name="output_aurora_cluster_security_group_ids"></a> [aurora\_cluster\_security\_group\_ids](#output\_aurora\_cluster\_security\_group\_ids) | A list of all security group ids associated with Aurora rds cluster |
 <!-- END_TF_DOCS -->

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -58,6 +58,19 @@ module "aurora_vpc_s" {
 }
 
 ######################################
+# Security groups for for Aurora DB
+######################################
+
+resource "aws_default_security_group" "default_vpc_p" {
+  vpc_id = module.aurora_vpc_p.vpc_id
+}
+
+resource "aws_default_security_group" "default_vpc_s" {
+  count = var.setup_globaldb ? 1: 0
+  vpc_id = module.aurora_vpc_s.vpc_id
+}
+
+######################################
 # Create Aurora DB
 ######################################
 
@@ -82,4 +95,5 @@ module "aurora" {
   primary_instance_count   = var.primary_instance_count
   secondary_instance_count = var.secondary_instance_count
   snapshot_identifier      = var.snapshot_identifier
+  security_group_ids =  concat([ aws_default_security_group.default_vpc_p.id ],[try(aws_default_security_group.default_vpc_s[0].id,null)])
 }

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -61,7 +61,7 @@ variable "engine" {
 variable "engine_version_pg" {
   description = "Aurora PostgreSQL database engine version."
   type        = string
-  default     = "13.6"
+  default     = "15.3"
 }
 
 variable "engine_version_mysql" {

--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,9 @@ resource "aws_rds_cluster" "primary" {
   final_snapshot_identifier       = var.skip_final_snapshot ? null : "${var.final_snapshot_identifier_prefix}-${var.identifier}-${var.region}-${random_id.snapshot_id.hex}"
   snapshot_identifier             = var.snapshot_identifier != "" ? var.snapshot_identifier : null
   enabled_cloudwatch_logs_exports = local.logs_set
+  vpc_security_group_ids = length(var.security_group_ids) > 0 ? compact(distinct(var.security_group_ids)): null
   tags                            = var.tags
+
   depends_on = [
     # When this Aurora cluster is setup as a secondary, setting up the dependency makes sure to delete this cluster 1st before deleting current primary Cluster during terraform destroy
     # Comment out the following line if this cluster has changed role to be the primary Aurora cluster because of a failover for terraform destroy to work
@@ -231,6 +233,7 @@ resource "aws_rds_cluster" "secondary" {
   skip_final_snapshot              = var.skip_final_snapshot
   final_snapshot_identifier        = var.skip_final_snapshot ? null : "${var.final_snapshot_identifier_prefix}-${var.identifier}-${var.sec_region}-${random_id.snapshot_id.hex}"
   enabled_cloudwatch_logs_exports  = local.logs_set
+  vpc_security_group_ids = length(var.security_group_ids) > 0 ? compact(distinct(var.security_group_ids)): null
   tags                             = var.tags
   depends_on = [
     # When this Aurora cluster is setup as a secondary, setting up the dependency makes sure to delete this cluster 1st before deleting current primary Cluster during terraform destroy

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,3 +60,8 @@ output "aurora_cluster_instance_ids" {
   description = "A list of all Primary Aurora cluster instance ids"
   value       = aws_rds_cluster_instance.primary.*.id
 }
+
+output "aurora_cluster_security_group_ids" {
+  description = "A list of all security group ids associated with Aurora rds cluster"
+  value = try(aws_rds_cluster.primary.vpc_security_group_ids, [])
+}

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,9 @@ variable "enable_postgresql_log" {
   type        = bool
   default     = false
 }
+
+variable "security_group_ids" {
+  description = "List of VPC security groups to associate with the Cluster"
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
The current module does not support associating security groups with the aurora database cluster , the current pull request enables assigning security group ids to the cluster be it primary or secondary . 

The changes have been tested and the documentation has been updated too 